### PR TITLE
Request user playlists based on page size

### DIFF
--- a/src/components/playlists/Playlists.tsx
+++ b/src/components/playlists/Playlists.tsx
@@ -16,17 +16,17 @@ import s from './style.module.less';
 import GridCard from '../common/gridCard/GridCard';
 import paginationStyles from '../common/pagination/pagination.module.less';
 
+export const PLAYLISTS_PAGE_SIZE = 20;
+
 const Playlists = () => {
-  const PAGE_SIZE = 20;
   const currentBreakpoint = getMediaBreakpoint();
   const mobileView = currentBreakpoint.type === 'mobile';
 
   const linkCopiedHotjarEvent = () =>
     AnalyticsFactory.hotjar().event(HotjarEvents.PlaylistLinkCopied);
-
-  const { data: playlists, isLoading } = useOwnAndSharedPlaylistsQuery();
-
   const [page, setPage] = useState<number>(1);
+
+  const { data: playlists, isLoading } = useOwnAndSharedPlaylistsQuery(page);
 
   const handlePageChange = (newPage: number) => {
     window.scrollTo({ top: 0 });
@@ -41,7 +41,9 @@ const Playlists = () => {
           page={pageNb}
           mobileView={mobileView}
           currentPage={page}
-          totalItems={Math.ceil(playlists.pageSpec.totalElements / PAGE_SIZE)}
+          totalItems={Math.ceil(
+            playlists.pageSpec.totalElements / PLAYLISTS_PAGE_SIZE,
+          )}
         />
       );
     },
@@ -63,7 +65,7 @@ const Playlists = () => {
                 [paginationStyles.paginationEmpty]: !playlists.page.length,
               }),
               hideOnSinglePage: true,
-              pageSize: PAGE_SIZE,
+              pageSize: PLAYLISTS_PAGE_SIZE,
               showSizeChanger: false,
               onChange: handlePageChange,
               current: page,

--- a/src/hooks/api/playlistKeys.ts
+++ b/src/hooks/api/playlistKeys.ts
@@ -1,7 +1,7 @@
 const all = ['playlists'] as const;
 
 export const playlistKeys = {
-  ownAndShared: [...all, 'ownAndShared'] as const,
+  ownAndShared: (page: number) => [...all, 'ownAndShared', page] as const,
   own: [...all, 'own'] as const,
   detail: (id: string) => [...all, id] as const,
 };

--- a/src/hooks/api/playlistsQuery.test.ts
+++ b/src/hooks/api/playlistsQuery.test.ts
@@ -5,7 +5,7 @@ import { QueryClient } from 'react-query';
 import { FakeBoclipsClient } from 'boclips-api-client/dist/test-support';
 
 describe('playlistsQuery', () => {
-  it('will use list projection when loading users playlists', async () => {
+  it('will use list projection and convert page size when loading users playlists', async () => {
     const apiClient = new FakeBoclipsClient();
     const collectionsSpy = jest.spyOn(
       apiClient.collections,
@@ -14,13 +14,17 @@ describe('playlistsQuery', () => {
     // @ts-ignore
     apiClient.collections.getMySavedCollectionsWithoutDetails = collectionsSpy;
     const { result, waitFor } = renderHook(
-      () => useOwnAndSharedPlaylistsQuery(),
+      () => useOwnAndSharedPlaylistsQuery(1),
       {
         wrapper: wrapperWithClients(apiClient, new QueryClient()),
       },
     );
 
     await waitFor(() => result.current.isSuccess);
-    expect(collectionsSpy).toBeCalledWith({ origin: 'BO_WEB_APP' });
+    expect(collectionsSpy).toBeCalledWith({
+      page: 0,
+      size: 20,
+      origin: 'BO_WEB_APP',
+    });
   });
 });

--- a/src/hooks/api/playlistsQuery.ts
+++ b/src/hooks/api/playlistsQuery.ts
@@ -9,6 +9,7 @@ import { Collection } from 'boclips-api-client/dist/sub-clients/collections/mode
 import { displayNotification } from 'src/components/common/notification/displayNotification';
 import { CollectionsClient } from 'boclips-api-client/dist/sub-clients/collections/client/CollectionsClient';
 import { ListViewCollection } from 'boclips-api-client/dist/sub-clients/collections/model/ListViewCollection';
+import { PLAYLISTS_PAGE_SIZE } from 'src/components/playlists/Playlists';
 import { playlistKeys } from './playlistKeys';
 
 interface UpdatePlaylistProps {
@@ -21,10 +22,11 @@ interface PlaylistMutationCallbacks {
   onError: (playlistId: string) => void;
 }
 
-export const useOwnAndSharedPlaylistsQuery = () => {
+export const useOwnAndSharedPlaylistsQuery = (page: number) => {
   const client = useBoclipsClient();
-  return useQuery(playlistKeys.ownAndShared, () =>
-    doGetOwnAndSharedPlaylists(client),
+  const backendPageNumber = page - 1;
+  return useQuery(playlistKeys.ownAndShared(backendPageNumber), () =>
+    doGetOwnAndSharedPlaylists(client, backendPageNumber),
   );
 };
 
@@ -136,9 +138,13 @@ const doGetOwnPlaylists = (client: BoclipsClient) =>
     .getMyCollectionsWithoutDetails({ origin: 'BO_WEB_APP' })
     .then((playlists) => playlists.page);
 
-const doGetOwnAndSharedPlaylists = (client: BoclipsClient) =>
+const doGetOwnAndSharedPlaylists = (client: BoclipsClient, page: number) =>
   client.collections
-    .getMySavedCollectionsWithoutDetails({ origin: 'BO_WEB_APP' })
+    .getMySavedCollectionsWithoutDetails({
+      page,
+      size: PLAYLISTS_PAGE_SIZE,
+      origin: 'BO_WEB_APP',
+    })
     .then((playlists) => playlists);
 
 export const usePlaylistMutation = () => {

--- a/src/views/library/LibraryViewPagination.integrationTest.tsx
+++ b/src/views/library/LibraryViewPagination.integrationTest.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import App from 'src/App';
@@ -61,6 +61,23 @@ describe('LibraryView', () => {
 
     expect(await wrapper.findByText('Playlist 1')).toBeVisible();
     expect(await wrapper.findByText('Playlist 2')).toBeVisible();
+  });
+
+  it('loads playlists when paginating', async () => {
+    const client = new FakeBoclipsClient();
+    insertUser(client);
+    loadPlaylists(client, 41);
+
+    const wrapper = renderLibraryView(client);
+    expect(await wrapper.findByText('Playlist 0')).toBeVisible();
+
+    fireEvent.click(wrapper.getByRole('button', { name: 'Next page' }));
+    expect(await wrapper.findByText('Playlist 20')).toBeVisible();
+    expect(wrapper.queryByText('Playlist 0')).toBeNull();
+
+    fireEvent.click(wrapper.getByRole('button', { name: 'Next page' }));
+    expect(await wrapper.findByText('Playlist 40')).toBeVisible();
+    expect(wrapper.queryByText('Playlist 20')).toBeNull();
   });
 
   function loadPlaylists(client: FakeBoclipsClient, quantity: number) {


### PR DESCRIPTION
Bug from https://www.pivotaltracker.com/story/show/183453817

Before the fix, we showed the pagination buttons but changing the page did not affect the API query and we always displayed the same playlists. 
Passing the page number down now so we load the correct playlists.