### PR TITLE
Ship source maps in prod

### DIFF
--- a/webpack/webpack.prod.js
+++ b/webpack/webpack.prod.js
@@ -12,7 +12,7 @@ const kilobyte = 1024;
 
 module.exports = merge(common, {
   mode: 'production',
-  devtool: false,
+  devtool: 'source-map',
   output: {
     filename: '[name].[fullhash:20].js',
     chunkFilename: '[name].[chunkhash:20].chunk.js',


### PR DESCRIPTION
- These have no impact on bundle size as they are only loaded on dev tools being opened