### PR TITLE
Update logo link to reload document

### DIFF
--- a/src/components/logo/Logo.tsx
+++ b/src/components/logo/Logo.tsx
@@ -12,7 +12,7 @@ const Logo = (): ReactElement => {
     : 'CourseSpark logo - Go to homepage';
 
   return (
-    <Link to="/" aria-label={logoTitle} className={s.logo}>
+    <Link to="/" reloadDocument aria-label={logoTitle} className={s.logo}>
       {user?.organisation?.logoUrl ? (
         <img alt={logoTitle} src={user?.organisation?.logoUrl} />
       ) : (


### PR DESCRIPTION
Required for link on error page to reload the home page.

A side effect of this is that the logo causes a full reload from anywhere not just the error page rather than an internal react router reload. Not particularly happy with this but thought it would make sense to open this PR as a place to discuss this.

[[#182593964]](https://www.pivotaltracker.com/story/show/182593964)