### PR TITLE
Update Sparks page styling

### DIFF
--- a/src/components/sparks/widget/card/SparksCard.tsx
+++ b/src/components/sparks/widget/card/SparksCard.tsx
@@ -23,17 +23,19 @@ const SparksCard = ({ provider }: Props) => {
       onClick={handleOnClick}
       className={s.sparksCard}
     >
-      <img
-        alt={`${provider.name} logo`}
-        src={provider.logoUrl}
-        className={s.sparksCardLogo}
-      />
-      <Typography.H1
-        size={{ mobile: 'md', tablet: 'md', desktop: 'lg' }}
-        className="mb-2 text-left"
-      >
-        {provider.name}
-      </Typography.H1>
+      <div>
+        <img
+          alt={`${provider.name} logo`}
+          src={provider.logoUrl}
+          className={s.sparksCardLogo}
+        />
+        <Typography.H1
+          size={{ mobile: 'md', tablet: 'md', desktop: 'lg' }}
+          className="mb-2 text-left"
+        >
+          {provider.name}
+        </Typography.H1>
+      </div>
       <Typography.Body className={s.sparksCardDescription}>
         {provider.description}
       </Typography.Body>

--- a/src/components/sparks/widget/card/sparksCard.module.less
+++ b/src/components/sparks/widget/card/sparksCard.module.less
@@ -5,12 +5,14 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  justify-content: space-between;
   background-color: white;
   padding: 2rem;
   border-radius: 4px;
   border: 2px solid transparent;
   box-shadow: 0 0.5rem 0.75rem rgba(0, 0, 0, 0.05);
   #focus;
+
   &:hover {
     box-shadow: 0 1.5rem 3rem rgba(0, 0, 0, 0.08);
     border: 2px solid @gray-700;

--- a/src/components/sparks/widget/sparksWidget.module.less
+++ b/src/components/sparks/widget/sparksWidget.module.less
@@ -7,6 +7,7 @@
   place-content: start;
   margin-top: 2rem;
 }
+
 @media screen and (min-width: @screen-md) {
   .sparksCardWrapper {
     position: relative;
@@ -18,16 +19,16 @@
 @media screen and (min-width: @screen-lg) {
   .sparksCardWrapper {
     position: relative;
-    padding: 0 4rem 0 4rem;
+    padding: 0 ~"min(6.5vw, 7rem)" 0 ~"min(6.5vw, 7rem)";
     grid-template-columns: repeat(3, minmax(0, 1fr));
 
     &:after {
-      @apply rounded;
+    @apply rounded;
       content: '';
-      width: 120%;
+      width: 110%;
       height: 100%;
       top: 2rem;
-      left: -10%;
+      left: -5%;
       background: @blue-100;
       position: absolute;
       z-index: -1;


### PR DESCRIPTION
- add space between provider logo and name and the description
- make the spacing between provider tiles and the blue background align more closely to the Figma design
- make the tiles behave more nicely when the viewport width is reduced - the padding within the tile should be maintained

[#184748068]