### PR TITLE
Align account menu popup to show inside the page

### DIFF
--- a/src/components/navButtons/newstyle.module.less
+++ b/src/components/navButtons/newstyle.module.less
@@ -104,6 +104,7 @@
   width: 250px;
   height: 190px;
   bottom: -188px;
+  right: 38px;
   background: white;
   box-shadow: 0px 2px 10px #e8e8e8;
   border-radius: 4px;


### PR DESCRIPTION
- aligned it to our grid that uses 38px so it should always align up with the button we use to show this menu

  [#185026224]