### PR TITLE
Remove reference to BO_WEB_APP_SPARKS

### DIFF
--- a/cypress/e2e/Homepage.cy.ts
+++ b/cypress/e2e/Homepage.cy.ts
@@ -1,5 +1,4 @@
 // homepage feature flags
-// featureGate role: BO_WEB_APP_SPARKS
 // featureGate link: cart
 
 import { UserFactory } from 'boclips-api-client/dist/test-support/UserFactory';


### PR DESCRIPTION
This feature flag is no longer in use and will be removed from user-service shortly.

[[#186149415]](https://www.pivotaltracker.com/story/show/186149415)