### PR TITLE
Revert bodal footer to use justify center for one button

### DIFF
--- a/src/components/common/bodal/style.module.less
+++ b/src/components/common/bodal/style.module.less
@@ -88,8 +88,12 @@
     }
 
     .modalFooter {
-      @apply flex justify-between relative mt-8 p-0 w-auto h-11 rounded-none;
+      @apply flex relative mt-8 p-0 w-auto h-11 rounded-none;
       box-shadow: none;
+    }
+
+    .oneButtonFooter {
+      justify-content: center;
     }
   }
 }


### PR DESCRIPTION
- When using justify between with only one item it is flush with the start not placed in the centre

[[#187131727]](https://www.pivotaltracker.com/story/show/187131727)