### PR TITLE
Update share video modal with design rev changes

### DIFF
--- a/src/components/cart/AdditionalServices/Trim/DurationInput.tsx
+++ b/src/components/cart/AdditionalServices/Trim/DurationInput.tsx
@@ -12,6 +12,7 @@ interface Props {
   onFocus: (event: React.FocusEvent<HTMLInputElement>) => void;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   disabled?: boolean;
+  placeholder?: string;
 }
 
 export const BASE_DURATION = '00:00';
@@ -26,6 +27,7 @@ export const DurationInput = ({
   id,
   value,
   disabled = false,
+  placeholder = BASE_DURATION,
 }: Props) => {
   const debouncedIsValid = useDebounce(isValid, 100);
   const onKeyPress = (e) => {
@@ -51,7 +53,7 @@ export const DurationInput = ({
         onKeyPress={onKeyPress}
         onFocus={onFocus}
         onChange={onChange}
-        placeholder={BASE_DURATION}
+        placeholder={placeholder}
         id={id}
         value={value || ''}
         disabled={disabled}

--- a/src/components/common/bodal/Bodal.tsx
+++ b/src/components/common/bodal/Bodal.tsx
@@ -7,7 +7,6 @@ import React, {
 import Button from '@boclips-ui/button';
 import CloseIconSVG from 'src/resources/icons/cross-icon.svg';
 import { LoadingOutlined } from '@ant-design/icons';
-import { useMediaBreakPoint } from '@boclips-ui/use-media-breakpoints';
 import { TextButton } from 'src/components/common/textButton/TextButton';
 import { handleEscapeKeyEvent } from 'src/services/handleKeyEvent';
 import FocusTrap from 'focus-trap-react';
@@ -57,9 +56,6 @@ export const Bodal: React.FC<Props> = ({
   footerText,
   extraButton,
 }: PropsWithChildren<Props>) => {
-  const breakpoints = useMediaBreakPoint();
-  const mobileView = breakpoints.type === 'mobile';
-
   const getSpinner = (): ReactElement =>
     isLoading ? (
       <span data-qa="spinner" className="pb-2">
@@ -116,7 +112,6 @@ export const Bodal: React.FC<Props> = ({
         <div className={c(s.modal, { [s.small]: smallSize })} ref={ref}>
           <div className={s.modalContent}>
             <div className={s.modalHeader}>
-              {mobileView && <span />}
               <Typography.H1
                 size="sm"
                 className="text-gray-900"

--- a/src/components/common/bodal/style.module.less
+++ b/src/components/common/bodal/style.module.less
@@ -31,7 +31,7 @@
   }
 
   .modalHeader {
-    @apply flex justify-items-start items-center mb-7 h-8;
+    @apply flex flex-row justify-between mb-7 h-8;
 
     svg {
       width: 1.5rem;

--- a/src/components/videoShareButton/VideoShareButton.tsx
+++ b/src/components/videoShareButton/VideoShareButton.tsx
@@ -28,6 +28,7 @@ export const VideoShareButton = ({
   video,
 }: VideoShareButtonProps) => {
   const { data: user } = useGetUserQuery();
+  const videoDuration = video.playback.duration.format('mm:ss');
 
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [startTimeEnabled, setStartTimeEnabled] = useState(false);
@@ -35,9 +36,7 @@ export const VideoShareButton = ({
   const [startDurationValid, setStartDurationValid] = useState(true);
 
   const [endTimeEnabled, setEndTimeEnabled] = useState(false);
-  const [endDuration, setEndDuration] = useState(
-    video.playback.duration.format('mm:ss'),
-  );
+  const [endDuration, setEndDuration] = useState(videoDuration);
   const [endDurationValid, setEndDurationValid] = useState(true);
 
   const shareLink = getShareableVideoLink(
@@ -132,9 +131,9 @@ export const VideoShareButton = ({
         >
           <Typography.Body as="div" className="mb-8">
             Students need both the link and your unique teacher code to access
-            to play video(s).
+            and play video(s).
           </Typography.Body>
-          <div className="flex justify-between">
+          <div className="flex justify-start">
             <div className="flex items-center">
               <BoCheckbox
                 checked={startTimeEnabled}
@@ -157,7 +156,7 @@ export const VideoShareButton = ({
                 onFocus={() => {}}
               />
             </div>
-            <div className="flex items-center">
+            <div className="flex items-center ml-16">
               <BoCheckbox
                 aria-label="end time enabled"
                 checked={endTimeEnabled}
@@ -178,6 +177,7 @@ export const VideoShareButton = ({
                 isValid={endDurationValid}
                 onBlur={validateFields}
                 onFocus={() => {}}
+                placeholder={videoDuration}
               />
             </div>
           </div>


### PR DESCRIPTION
- Copy change for modal body text
- Realign modal close button to top right for mobile and tablet views
- Update duration pickers to be left aligned with margin inbetween
- Set placeholder text for end time to video duration

[[#187131727]](https://www.pivotaltracker.com/story/show/187131727)