### PR TITLE
Update bodal z-index to avoid clash with cookie banner

### DIFF
--- a/src/components/common/bodal/style.module.less
+++ b/src/components/common/bodal/style.module.less
@@ -5,7 +5,7 @@
   width: 100vw;
   height: 100vh;
   position: fixed;
-  z-index: 51; // header is set to 50
+  z-index: 2147483641; // cookie banner is set to 2147483640
   overflow: auto;
   top: 0;
   left: 0;


### PR DESCRIPTION
- The current case is the marketingInfo form which is clashing with the cookie banner.