### PR TITLE
Bump api-client to remove shareCode references

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,7 @@
         "@types/jest-axe": "^3.5.6",
         "audit-ci": "^6.6.1",
         "autoprefixer": "10.4.5",
-        "boclips-api-client": "91.0.1",
+        "boclips-api-client": "92.0.0",
         "boclips-percy-baseline": "0.3.0",
         "css-loader": "^6.10.0",
         "css-minimizer-webpack-plugin": "^5.0.1",
@@ -2762,9 +2762,9 @@
       }
     },
     "node_modules/@headlessui/react": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.1.8.tgz",
-      "integrity": "sha512-uajqVkAcVG/wHwG9Fh5PFMcFpf2VxM4vNRNKxRjuK009kePVur8LkuuygHfIE+2uZ7z7GnlTtYsyUe6glPpTLg==",
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.1.10.tgz",
+      "integrity": "sha512-6mLa2fjMDAFQi+/R10B+zU3edsUk/MDtENB2zHho0lqKU1uzhAfJLUduWds4nCo8wbl3vULtC5rJfZAQ1yqIng==",
       "dependencies": {
         "@floating-ui/react": "^0.26.16",
         "@react-aria/focus": "^3.17.1",
@@ -8419,9 +8419,9 @@
       "license": "MIT"
     },
     "node_modules/boclips-api-client": {
-      "version": "91.0.1",
-      "resolved": "https://registry.npmjs.org/boclips-api-client/-/boclips-api-client-91.0.1.tgz",
-      "integrity": "sha512-Thcl3bhjoVFRK9gLI0fmXEZr3TxnLKsSBpp3BbJIjxkl/SXWtuXr+UVKjlHY3uS+uaX79++h+c6SoS7+/JqsSA==",
+      "version": "92.0.0",
+      "resolved": "https://registry.npmjs.org/boclips-api-client/-/boclips-api-client-92.0.0.tgz",
+      "integrity": "sha512-VUgafUngGEIncVNYMvwAfyM73wq2q0lj2bDohHC2NN1Tu5V5MIemQWFfOqwOKy+m1YJCokm01Fn5PJ7VtaepKA==",
       "dependencies": {
         "uuid": "^9.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/jest-axe": "^3.5.6",
     "audit-ci": "^6.6.1",
     "autoprefixer": "10.4.5",
-    "boclips-api-client": "91.0.1",
+    "boclips-api-client": "92.0.0",
     "boclips-percy-baseline": "0.3.0",
     "css-loader": "^6.10.0",
     "css-minimizer-webpack-plugin": "^5.0.1",

--- a/src/components/playlists/playlistHeader/OptionsButton.test.tsx
+++ b/src/components/playlists/playlistHeader/OptionsButton.test.tsx
@@ -346,7 +346,7 @@ describe('OptionsButton', () => {
       });
     });
 
-    it('emits event when Share code link is copied', async () => {
+    it('emits event when share link link is copied', async () => {
       Object.assign(navigator, {
         clipboard: {
           writeText: () => Promise.resolve(),

--- a/src/components/playlists/playlistHeader/PlaylistHeader.test.tsx
+++ b/src/components/playlists/playlistHeader/PlaylistHeader.test.tsx
@@ -191,7 +191,7 @@ describe('Playlist Header', () => {
       ).toBeNull();
     });
 
-    it('shows share code button', async () => {
+    it('shows share link button', async () => {
       const fakeClient = new FakeBoclipsClient();
       fakeClient.users.insertCurrentUser(
         UserFactory.sample({

--- a/src/components/shareLinkButton/PlaylistShareLinkButton.test.tsx
+++ b/src/components/shareLinkButton/PlaylistShareLinkButton.test.tsx
@@ -49,7 +49,7 @@ describe('playlist share link button', () => {
     expect(wrapper.queryByText('Share')).toBeNull();
   });
 
-  it('displays playlist share code modal on click', async () => {
+  it('displays playlist share link modal on click', async () => {
     const wrapper = renderShareButton();
     await openShareModal(wrapper);
 
@@ -73,12 +73,12 @@ describe('playlist share link button', () => {
   it(`copies share link but doesn't close modal on clicking main button`, async () => {
     const apiClient = new FakeBoclipsClient();
     jest.spyOn(navigator.clipboard, 'writeText');
-    const trackCollectionShareCodeSpy = jest.spyOn(
-      apiClient.shareCodes,
-      'trackCollectionShareCode',
+    const trackCollectionShareLinkSpy = jest.spyOn(
+      apiClient.shareLinks,
+      'trackCollectionShareLink',
     );
     // @ts-ignore
-    apiClient.shareCodes.trackCollectionShareCode = trackCollectionShareCodeSpy;
+    apiClient.shareLinks.trackCollectionShareLink = trackCollectionShareLinkSpy;
     const wrapper = renderShareButton(apiClient);
     await openShareModal(wrapper);
 
@@ -91,7 +91,7 @@ describe('playlist share link button', () => {
       await wrapper.findByRole('button', { name: 'Copy link' }),
     );
 
-    expect(trackCollectionShareCodeSpy).toHaveBeenCalledWith('playlist-id');
+    expect(trackCollectionShareLinkSpy).toHaveBeenCalledWith('playlist-id');
 
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
       getShareablePlaylistLink('playlist-id', 'user-id'),
@@ -128,7 +128,7 @@ describe('playlist share link button', () => {
     );
   });
 
-  it('emits events when share code modal opened', async () => {
+  it('emits events when share link modal opened', async () => {
     const client = new FakeBoclipsClient();
     const wrapper = renderShareButton(client);
     await openShareModal(wrapper);
@@ -147,7 +147,7 @@ describe('playlist share link button', () => {
     });
   });
 
-  it('emits events when share code link is copied', async () => {
+  it('emits events when share link link is copied', async () => {
     const client = new FakeBoclipsClient();
     const wrapper = renderShareButton(client);
     await openShareModal(wrapper);

--- a/src/components/shareLinkButton/PlaylistShareLinkButton.tsx
+++ b/src/components/shareLinkButton/PlaylistShareLinkButton.tsx
@@ -55,7 +55,7 @@ export const PlaylistShareLinkButton = ({
       subtype: 'PLAYLIST_SHARE_LINK_COPIED',
     });
 
-    client.shareCodes.trackCollectionShareCode(playlist.id);
+    client.shareLinks.trackCollectionShareLink(playlist.id);
 
     navigator.clipboard.writeText(shareLink).then(() => {
       displayNotification(

--- a/src/components/shareLinkButton/VideoShareLinkButton.test.tsx
+++ b/src/components/shareLinkButton/VideoShareLinkButton.test.tsx
@@ -45,14 +45,14 @@ describe('video share link button', () => {
     expect(wrapper.queryByText('Share')).toBeNull();
   });
 
-  it('displays share code modal on click', async () => {
+  it('displays share link modal on click', async () => {
     const wrapper = renderShareButton();
     await openShareModal(wrapper);
 
     expect(wrapper.getByRole('dialog')).toBeInTheDocument();
     expect(wrapper.getByText('Share this video with students')).toBeVisible();
 
-    const body = wrapper.getByTestId('share-code-body');
+    const body = wrapper.getByTestId('share-link-body');
     expect(body).toBeVisible();
     expect(body.textContent).toEqual(
       'Students only need the link to access and play the video Tractor Video',
@@ -160,11 +160,11 @@ describe('video share link button', () => {
 
     jest.spyOn(navigator.clipboard, 'writeText');
     const trackVideoSpy = jest.spyOn(
-      apiClient.shareCodes,
-      'trackVideoShareCode',
+      apiClient.shareLinks,
+      'trackVideoShareLink',
     );
     // @ts-ignore
-    apiClient.shareCodes.trackVideoShareCode = trackVideoSpy;
+    apiClient.shareLinks.trackVideoShareLink = trackVideoSpy;
     const wrapper = renderShareButton(apiClient);
     await openShareModal(wrapper);
 

--- a/src/components/shareLinkButton/VideoShareLinkButton.tsx
+++ b/src/components/shareLinkButton/VideoShareLinkButton.tsx
@@ -107,7 +107,7 @@ export const VideoShareLinkButton = ({
     if (!startDurationValid || !endDurationValid) {
       return;
     }
-    client.shareCodes.trackVideoShareCode(video.id);
+    client.shareLinks.trackVideoShareLink(video.id);
 
     navigator.clipboard.writeText(shareLink).then(() => {
       displayNotification(
@@ -152,7 +152,7 @@ export const VideoShareLinkButton = ({
           <Typography.Body
             as="div"
             className="mb-14 text-gray-800"
-            data-qa="share-code-body"
+            data-qa="share-link-body"
           >
             Students only need the link to access and play the video{' '}
             <Typography.Body weight="medium">{video.title}</Typography.Body>

--- a/src/components/shareLinkButton/playlistsBookmark/bookmarkModal/BookmarkModal.tsx
+++ b/src/components/shareLinkButton/playlistsBookmark/bookmarkModal/BookmarkModal.tsx
@@ -111,7 +111,7 @@ const BookmarkModal = ({
       <Typography.Body
         as="div"
         className="mb-14 text-gray-800"
-        data-qa="share-code-body"
+        data-qa="share-link-body"
       >
         Set custom start and end times to bookmark a specific section of the
         video for students to focus on.

--- a/src/components/videoCard/VideoCardWrapper.test.tsx
+++ b/src/components/videoCard/VideoCardWrapper.test.tsx
@@ -30,7 +30,7 @@ describe('Video card', () => {
         },
       ],
       playback: PlaybackFactory.sample({
-        type: 'YOUTUBE',
+        type: 'STREAM',
       }),
       price: {
         amount: 100,

--- a/src/views/search/SearchResultsView.integrationTest.tsx
+++ b/src/views/search/SearchResultsView.integrationTest.tsx
@@ -50,7 +50,7 @@ describe('SearchResults', () => {
           },
         ],
         playback: PlaybackFactory.sample({
-          type: 'YOUTUBE',
+          type: 'STREAM',
         }),
       }),
     ];


### PR DESCRIPTION
Also removes references to youtube playback type

[[sc-1930]](https://app.shortcut.com/boclips/story/1930/remove-unique-access-code) [[sc-1933]](https://app.shortcut.com/boclips/story/1933/remove-youtube-videos-as-a-concept)