### PR TITLE
Display accounts in users list for parent account

### DIFF
--- a/src/components/usersList/UsersList.tsx
+++ b/src/components/usersList/UsersList.tsx
@@ -80,6 +80,7 @@ export const UsersList = ({ onEditUser, onRemoveUser }: Props) => {
             canEdit={canEditUser}
             onRemove={() => onRemoveUser(accountUser)}
             canRemove={canRemoveUser}
+            displayAccount={!isLoadingAccount && account.products.length > 0}
           />
         )}
         pagination={{

--- a/src/components/usersList/UsersListItem.test.tsx
+++ b/src/components/usersList/UsersListItem.test.tsx
@@ -7,6 +7,7 @@ import { BoclipsClientProvider } from 'src/components/common/providers/BoclipsCl
 import { FakeBoclipsClient } from 'boclips-api-client/dist/test-support';
 import { Product } from 'boclips-api-client/dist/sub-clients/accounts/model/Account';
 import { UserRole } from 'boclips-api-client/dist/sub-clients/users/model/UserRole';
+import { BoclipsClient } from 'boclips-api-client';
 
 describe('UsersListRow', () => {
   it('shows user role', () => {
@@ -20,7 +21,11 @@ describe('UsersListRow', () => {
       },
     };
 
-    const wrapper = renderWrapper(user, jest.fn, false);
+    const wrapper = renderWrapper({
+      user,
+      onEdit: jest.fn(),
+      canEdit: false,
+    });
 
     expect(
       within(wrapper.getByTestId('user-info-field-Role')).getByText('Admin'),
@@ -38,7 +43,11 @@ describe('UsersListRow', () => {
       },
     };
 
-    const wrapper = renderWrapper(user, jest.fn, false);
+    const wrapper = renderWrapper({
+      user,
+      onEdit: jest.fn(),
+      canEdit: false,
+    });
 
     expect(wrapper.getByTestId('skeleton')).toBeVisible();
   });
@@ -57,7 +66,11 @@ describe('UsersListRow', () => {
     const client = new FakeBoclipsClient();
     expect(client.links.updateUser).not.toBeNull();
 
-    const wrapper = renderWrapper(user, jest.fn(), true);
+    const wrapper = renderWrapper({
+      user,
+      onEdit: jest.fn(),
+      canEdit: true,
+    });
 
     expect(await wrapper.findByText('Edit')).toBeVisible();
   });
@@ -76,7 +89,11 @@ describe('UsersListRow', () => {
     const client = new FakeBoclipsClient();
     expect(client.links.deleteUser).not.toBeNull();
 
-    const wrapper = renderWrapper(user, jest.fn(), true);
+    const wrapper = renderWrapper({
+      user,
+      onEdit: jest.fn(),
+      canEdit: true,
+    });
 
     expect(await wrapper.findByText('Remove')).toBeVisible();
   });
@@ -92,9 +109,93 @@ describe('UsersListRow', () => {
       },
     };
 
-    const wrapper = renderWrapper(user, jest.fn(), true);
+    const wrapper = renderWrapper({
+      user,
+      onEdit: jest.fn(),
+      canEdit: true,
+    });
 
     expect(wrapper.queryByText('Can order videos')).not.toBeInTheDocument();
+  });
+
+  it('doesnt display account column when flag is unset', async () => {
+    const user: AccountUser = {
+      id: 'id-1',
+      email: 'joebiden@gmail.com',
+      firstName: 'Joe',
+      lastName: 'Biden',
+      userRoles: {
+        [Product.LIBRARY]: UserRole.VIEWER,
+      },
+    };
+
+    const wrapper = renderWrapper({
+      user,
+      onEdit: jest.fn(),
+      canEdit: true,
+      displayAccount: false,
+    });
+
+    expect(wrapper.queryByText('Account')).not.toBeInTheDocument();
+    expect(wrapper.queryByText('District/School')).not.toBeInTheDocument();
+  });
+
+  it('displays account column when flag is set with header "Account" when not classroom', async () => {
+    const user: AccountUser = {
+      id: 'id-1',
+      email: 'joebiden@gmail.com',
+      firstName: 'Joe',
+      lastName: 'Biden',
+      userRoles: {
+        [Product.LIBRARY]: UserRole.VIEWER,
+      },
+      account: {
+        name: 'Secret organisation',
+        id: 'account-id',
+      },
+    };
+
+    const wrapper = renderWrapper({
+      user,
+      onEdit: jest.fn(),
+      canEdit: true,
+      displayAccount: true,
+      product: Product.LIBRARY,
+    });
+
+    expect(await wrapper.findByText('Account')).toBeVisible();
+    expect(await wrapper.findByText('Secret organisation')).toBeVisible();
+
+    expect(wrapper.queryByText('District/School')).not.toBeInTheDocument();
+  });
+
+  it('displays account column when flag is set with header "District/School" when classroom', async () => {
+    const user: AccountUser = {
+      id: 'id-1',
+      email: 'joebiden@gmail.com',
+      firstName: 'Joe',
+      lastName: 'Biden',
+      userRoles: {
+        [Product.LIBRARY]: UserRole.VIEWER,
+      },
+      account: {
+        name: 'Generic town elementary',
+        id: 'account-id',
+      },
+    };
+
+    const wrapper = renderWrapper({
+      user,
+      onEdit: jest.fn(),
+      canEdit: true,
+      displayAccount: true,
+      product: Product.CLASSROOM,
+    });
+
+    expect(await wrapper.findByText('District/School')).toBeVisible();
+    expect(await wrapper.findByText('Generic town elementary')).toBeVisible();
+
+    expect(wrapper.queryByText('Account')).not.toBeInTheDocument();
   });
 
   it('doesnt display ui elements if user doesnt have necessary links', () => {
@@ -112,29 +213,46 @@ describe('UsersListRow', () => {
     delete client.links.deleteUser;
     delete client.links.updateUser;
 
-    const wrapper = renderWrapper(user, jest.fn(), true, client);
+    const wrapper = renderWrapper({
+      user,
+      onEdit: jest.fn(),
+      canEdit: true,
+      client,
+    });
 
     expect(wrapper.queryByText('Remove')).toBeNull();
     expect(wrapper.queryByText('Edit')).toBeNull();
   });
 
-  const renderWrapper = (
-    user: AccountUser,
-    onEdit: (user: AccountUser) => void,
-    canEdit: boolean,
+  interface RenderOptions {
+    user: AccountUser;
+    onEdit: (user: AccountUser) => void;
+    canEdit: boolean;
+    displayAccount?: boolean;
+    product?: Product;
+    client?: BoclipsClient;
+  }
+
+  const renderWrapper = ({
+    user,
+    onEdit,
+    canEdit,
     client = new FakeBoclipsClient(),
-  ) => {
+    product = Product.LIBRARY,
+    displayAccount = false,
+  }: RenderOptions) => {
     return render(
       <BoclipsClientProvider client={client}>
         <QueryClientProvider client={new QueryClient()}>
           <UsersListItem
             user={user}
-            product={Product.LIBRARY}
+            product={product}
             isLoading
             onEdit={onEdit}
             canEdit={canEdit}
             onRemove={() => {}}
             canRemove
+            displayAccount={displayAccount}
           />
         </QueryClientProvider>
       </BoclipsClientProvider>,

--- a/src/components/usersList/UsersListItem.tsx
+++ b/src/components/usersList/UsersListItem.tsx
@@ -23,6 +23,7 @@ export interface Props {
   canEdit: boolean;
   onRemove: (user: AccountUser) => void;
   canRemove: boolean;
+  displayAccount: boolean;
 }
 
 export const UsersListItem = ({
@@ -33,6 +34,7 @@ export const UsersListItem = ({
   canEdit,
   onRemove,
   canRemove,
+  displayAccount,
 }: Props) => {
   return (
     <li
@@ -44,6 +46,12 @@ export const UsersListItem = ({
         value={`${user.firstName} ${user.lastName}`}
       />
       <UserInformationField name="Email address" value={user.email} />
+      {displayAccount && (
+        <UserInformationField
+          name={product === Product.CLASSROOM ? 'District/School' : 'Account'}
+          value={user.account?.name}
+        />
+      )}
       <UserInformationField
         name="Role"
         value={toTitleCase(user.userRoles?.[product])}


### PR DESCRIPTION
[[sc-2538]](https://app.shortcut.com/boclips/story/2538/parent-accounts-admins-should-see-corresponding-sub-accounts-in-web-app)