### PR TITLE
Even more n+1 video calls fixes

### DIFF
--- a/src/components/carousel/FeaturedPlaylists.tsx
+++ b/src/components/carousel/FeaturedPlaylists.tsx
@@ -4,6 +4,7 @@ import 'pure-react-carousel/dist/react-carousel.es.css';
 import { Carousel } from 'src/components/common/carousel/Carousel';
 import { PromotedForProduct } from 'boclips-api-client/dist/sub-clients/collections/model/PromotedForProduct';
 import { PlaylistSlide } from 'src/components/carousel/PlaylistSlide';
+import { useGetVideos } from 'src/hooks/api/videoQuery';
 import s from './styles.module.less';
 
 interface Props {
@@ -30,12 +31,22 @@ const FeaturedPlaylists = ({ product }: Props) => {
     [retrievedPlaylists],
   );
 
+  const firstVideoIds =
+    nonEmptyPlaylists?.map((playlist) => playlist.assets[0].id.videoId) ?? [];
+  const { data: firstVideos } = useGetVideos(firstVideoIds);
+
   const playlistSlides = useMemo(
     () =>
       nonEmptyPlaylists?.map((playlist) => (
-        <PlaylistSlide key={playlist.id} playlist={playlist} />
+        <PlaylistSlide
+          key={playlist.id}
+          playlist={playlist}
+          video={firstVideos?.find(
+            (video) => video.id === playlist.assets[0].id.videoId,
+          )}
+        />
       )),
-    [nonEmptyPlaylists],
+    [nonEmptyPlaylists, firstVideos],
   );
 
   if (isInitialLoading) {

--- a/src/components/carousel/PlaylistSlide.tsx
+++ b/src/components/carousel/PlaylistSlide.tsx
@@ -2,17 +2,15 @@ import { Typography } from '@boclips-ui/typography';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import Thumbnail from 'src/components/playlists/thumbnails/Thumbnail';
-import { useFindOrGetVideo } from 'src/hooks/api/videoQuery';
 import { Collection } from 'boclips-api-client/dist/sub-clients/collections/model/Collection';
+import { Video } from 'boclips-api-client/dist/sub-clients/videos/model/Video';
 
 interface Props {
   playlist: Collection;
+  video?: Video;
 }
 
-export const PlaylistSlide = ({ playlist }: Props) => {
-  const videoId = playlist.assets[0].id.videoId;
-  const { data: video } = useFindOrGetVideo(videoId);
-
+export const PlaylistSlide = ({ playlist, video }: Props) => {
   return (
     <Link
       to={{

--- a/src/components/playlists/PlaylistCard.tsx
+++ b/src/components/playlists/PlaylistCard.tsx
@@ -11,13 +11,18 @@ import { Product } from 'boclips-api-client/dist/sub-clients/accounts/model/Acco
 import { CopyButton } from 'src/components/common/copyLinkButton/CopyButton';
 import { Constants } from 'src/AppConstants';
 import { PlaylistShareLinkButton } from 'src/components/shareLinkButton/PlaylistShareLinkButton';
+import { Video } from 'boclips-api-client/dist/sub-clients/videos/model/Video';
 import s from './style.module.less';
 
 interface PlaylistCardProps {
   playlist: ListViewCollection;
+  thumbnailVideos?: Video[];
 }
 
-const PlaylistCard: React.FC<PlaylistCardProps> = ({ playlist }) => {
+const PlaylistCard: React.FC<PlaylistCardProps> = ({
+  playlist,
+  thumbnailVideos,
+}) => {
   const linkCopiedHotjarEvent = () =>
     AnalyticsFactory.hotjar().event(HotjarEvents.PlaylistLinkCopied);
 
@@ -29,7 +34,7 @@ const PlaylistCard: React.FC<PlaylistCardProps> = ({ playlist }) => {
         name={playlist.title}
         header={
           <Link tabIndex={-1} to={`/playlists/${playlist.id}`} aria-hidden>
-            <Thumbnails assets={playlist.assets} />
+            <Thumbnails assets={playlist.assets} videos={thumbnailVideos} />
           </Link>
         }
         subheader={

--- a/src/components/playlists/playlistList/PlaylistList.tsx
+++ b/src/components/playlists/playlistList/PlaylistList.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import c from 'classnames';
 import PlaylistCard from 'src/components/playlists/PlaylistCard';
 import { PlaylistEmptyState } from 'src/components/playlists/emptyState/EmptyState';
+import { useGetVideos } from 'src/hooks/api/videoQuery';
 import s from '../style.module.less';
 import paginationStyles from '../../common/pagination/pagination.module.less';
 
@@ -27,6 +28,11 @@ const PlaylistList: React.FC<PlaylistListProps> = ({
 }) => {
   const currentBreakpoint = getMediaBreakpoint();
   const mobileView = currentBreakpoint.type === 'mobile';
+
+  const allThumbnailVideoIds = playlists.page.flatMap((playlist) =>
+    playlist.assets.slice(0, 3).map((asset) => asset.id.videoId),
+  );
+  const { data: allThumbnailVideos } = useGetVideos(allThumbnailVideoIds);
 
   const itemRender = React.useCallback(
     (pageNumber: number, type: string) => (
@@ -62,9 +68,17 @@ const PlaylistList: React.FC<PlaylistListProps> = ({
         itemRender,
       }}
       dataSource={playlists.page}
-      renderItem={(playlist: ListViewCollection) => (
-        <PlaylistCard playlist={playlist} />
-      )}
+      renderItem={(playlist: ListViewCollection) => {
+        const playlistVideoIds = playlist.assets
+          .slice(0, 3)
+          .map((asset) => asset.id.videoId);
+        const thumbnailVideos = allThumbnailVideos?.filter((video) =>
+          playlistVideoIds.includes(video.id),
+        );
+        return (
+          <PlaylistCard playlist={playlist} thumbnailVideos={thumbnailVideos} />
+        );
+      }}
     />
   ) : (
     <PlaylistEmptyState playlistType={playlistType} />

--- a/src/components/playlists/thumbnails/Thumbnails.tsx
+++ b/src/components/playlists/thumbnails/Thumbnails.tsx
@@ -1,16 +1,15 @@
 import { ListViewAsset } from 'boclips-api-client/dist/sub-clients/videos/model/ListViewVideo';
 import { Video } from 'boclips-api-client/dist/sub-clients/videos/model/Video';
 import React from 'react';
-import { useGetVideos } from 'src/hooks/api/videoQuery';
 import s from './style.module.less';
 
 interface Props {
   assets: ListViewAsset[];
+  videos?: Video[];
 }
 
-const Thumbnails = ({ assets }: Props) => {
-  const videoIds = assets.slice(0, 3).map((asset) => asset.id.videoId);
-  const { data: videos, isLoading } = useGetVideos(videoIds);
+const Thumbnails = ({ assets, videos }: Props) => {
+  const thumbnailVideoIds = assets.slice(0, 3).map((asset) => asset.id.videoId);
 
   const getThumbnailUrl = (video: Video) =>
     video.playback?.links?.thumbnail?.getOriginalLink();
@@ -18,8 +17,8 @@ const Thumbnails = ({ assets }: Props) => {
   return (
     <div className={s.thumbnailsContainer}>
       {[0, 1, 2].map((i) => {
-        const video = videos?.[i];
-        if (video && !isLoading) {
+        const video = videos?.find((v) => v.id === thumbnailVideoIds[i]);
+        if (video) {
           return (
             <div
               className={s.thumbnails}


### PR DESCRIPTION
Even more fixes for n+1 issues this time for featured playlists (displayed on the home page) and the playlists page.

[[sc-2753]](https://app.shortcut.com/boclips/story/2753/persistent-n-1-alert-in-sentry)